### PR TITLE
Fix DuplicateWidgetID error

### DIFF
--- a/20220124-streamlitchat/streamlit_app.py
+++ b/20220124-streamlitchat/streamlit_app.py
@@ -35,5 +35,5 @@ def generate_answer():
 
 st.text_input("Talk to the bot", key="input_text", on_change=generate_answer)
 
-for chat in st.session_state.history:
-    st_message(**chat)  # unpacking
+for i in range(len(st.session_state.history)-1, -1, -1):
+    st_message(**st.session_state.history[i], key=str(i)) #unpacking

--- a/20220124-streamlitchat/streamlit_app.py
+++ b/20220124-streamlitchat/streamlit_app.py
@@ -35,5 +35,5 @@ def generate_answer():
 
 st.text_input("Talk to the bot", key="input_text", on_change=generate_answer)
 
-for i in range(len(st.session_state.history)-1, -1, -1):
-    st_message(**st.session_state.history[i], key=str(i)) #unpacking
+for i, chat in enumerate(st.session_state.history):
+    st_message(**chat, key=str(i)) #unpacking


### PR DESCRIPTION
Hey, I saw your guide on YouTube and I encountered an error that I noticed more people had experienced. I found a solution that creates a key for each historical chat text.